### PR TITLE
Extend TimeCoin converter for multiple units

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,0 +1,51 @@
+# Time Currency Concept
+
+This repository explores a simple concept where time can be exchanged like a
+digital currency. Each unit, called a **TimeCoin**, represents one minute of
+human time. The goal is to create a minimal specification and tools for
+converting between traditional time measurements and this hypothetical
+currency.
+
+## Rationale
+
+People often exchange their time for goods or services. By treating time as a
+currency, we could create an equitable way to trade tasks, knowledge, or labor
+without relying solely on standard money.
+
+## Converting Time to TimeCoins
+
+1 TimeCoin = 1 minute of time. This means that an hour of effort equals 60
+TimeCoins. The included `time_currency.py` utility demonstrates simple
+conversions.
+
+## Supported Units
+
+`time_currency.py` now handles several common time units. One TimeCoin always
+equals one minute, so other units are converted based on that relationship.
+
+- **Seconds** – 60 seconds = 1 TimeCoin
+- **Minutes** – 1 minute = 1 TimeCoin
+- **Hours** – 1 hour = 60 TimeCoins
+- **Days** – 1 day (24 hours) = 1,440 TimeCoins
+- **Months** – 1 month (30 days) ≈ 43,200 TimeCoins
+- **Years** – 1 year (365 days) ≈ 525,600 TimeCoins
+
+## Example Usage
+
+```bash
+$ python3 time_currency.py --minutes 90
+90 minutes is worth 90 TimeCoins
+
+$ python3 time_currency.py --coins 2
+2 TimeCoins equals 2 minutes
+
+$ python3 time_currency.py --hours 2
+2 hours is worth 120 TimeCoins
+
+$ python3 time_currency.py --coins 120 --to hours
+120 TimeCoins equals 2.0 hours
+```
+
+This project is purely experimental, but it offers a starting point for
+thinking about how "time is money" could become a viable, transferable
+currency.

--- a/time_currency.py
+++ b/time_currency.py
@@ -1,0 +1,116 @@
+#!/usr/bin/env python3
+"""Convert between TimeCoins and several time units."""
+
+import argparse
+
+RATE = 1  # 1 TimeCoin per minute
+SECONDS_IN_MINUTE = 60
+MINUTES_IN_HOUR = 60
+HOURS_IN_DAY = 24
+DAYS_IN_MONTH = 30
+DAYS_IN_YEAR = 365
+
+
+def minutes_to_coins(minutes: float) -> float:
+    return minutes / RATE
+
+
+def seconds_to_coins(seconds: float) -> float:
+    return minutes_to_coins(seconds / SECONDS_IN_MINUTE)
+
+
+def hours_to_coins(hours: float) -> float:
+    return minutes_to_coins(hours * MINUTES_IN_HOUR)
+
+
+def days_to_coins(days: float) -> float:
+    return hours_to_coins(days * HOURS_IN_DAY)
+
+
+def months_to_coins(months: float) -> float:
+    return days_to_coins(months * DAYS_IN_MONTH)
+
+
+def years_to_coins(years: float) -> float:
+    return days_to_coins(years * DAYS_IN_YEAR)
+
+
+def coins_to_minutes(coins: float) -> float:
+    return coins * RATE
+
+
+def coins_to_seconds(coins: float) -> float:
+    return coins_to_minutes(coins) * SECONDS_IN_MINUTE
+
+
+def coins_to_hours(coins: float) -> float:
+    return coins_to_minutes(coins) / MINUTES_IN_HOUR
+
+
+def coins_to_days(coins: float) -> float:
+    return coins_to_hours(coins) / HOURS_IN_DAY
+
+
+def coins_to_months(coins: float) -> float:
+    return coins_to_days(coins) / DAYS_IN_MONTH
+
+
+def coins_to_years(coins: float) -> float:
+    return coins_to_days(coins) / DAYS_IN_YEAR
+
+
+def main() -> None:
+    parser = argparse.ArgumentParser(description="Convert between TimeCoins and various time units")
+    group = parser.add_mutually_exclusive_group(required=True)
+    group.add_argument("--seconds", type=float, help="Seconds to convert to TimeCoins")
+    group.add_argument("--minutes", type=float, help="Minutes to convert to TimeCoins")
+    group.add_argument("--hours", type=float, help="Hours to convert to TimeCoins")
+    group.add_argument("--days", type=float, help="Days to convert to TimeCoins")
+    group.add_argument("--months", type=float, help="Months (30 days) to convert to TimeCoins")
+    group.add_argument("--years", type=float, help="Years (365 days) to convert to TimeCoins")
+    group.add_argument("--coins", type=float, help="TimeCoins to convert to time")
+    parser.add_argument("--to", choices=["seconds", "minutes", "hours", "days", "months", "years"],
+                        default="minutes", help="Unit to convert TimeCoins into (default: minutes)")
+    args = parser.parse_args()
+
+    if args.seconds is not None:
+        coins = seconds_to_coins(args.seconds)
+        print(f"{args.seconds} seconds is worth {coins} TimeCoins")
+    elif args.minutes is not None:
+        coins = minutes_to_coins(args.minutes)
+        print(f"{args.minutes} minutes is worth {coins} TimeCoins")
+    elif args.hours is not None:
+        coins = hours_to_coins(args.hours)
+        print(f"{args.hours} hours is worth {coins} TimeCoins")
+    elif args.days is not None:
+        coins = days_to_coins(args.days)
+        print(f"{args.days} days is worth {coins} TimeCoins")
+    elif args.months is not None:
+        coins = months_to_coins(args.months)
+        print(f"{args.months} months is worth {coins} TimeCoins")
+    elif args.years is not None:
+        coins = years_to_coins(args.years)
+        print(f"{args.years} years is worth {coins} TimeCoins")
+    else:
+        if args.to == "seconds":
+            value = coins_to_seconds(args.coins)
+            print(f"{args.coins} TimeCoins equals {value} seconds")
+        elif args.to == "minutes":
+            value = coins_to_minutes(args.coins)
+            print(f"{args.coins} TimeCoins equals {value} minutes")
+        elif args.to == "hours":
+            value = coins_to_hours(args.coins)
+            print(f"{args.coins} TimeCoins equals {value} hours")
+        elif args.to == "days":
+            value = coins_to_days(args.coins)
+            print(f"{args.coins} TimeCoins equals {value} days")
+        elif args.to == "months":
+            value = coins_to_months(args.coins)
+            print(f"{args.coins} TimeCoins equals {value} months")
+        elif args.to == "years":
+            value = coins_to_years(args.coins)
+            print(f"{args.coins} TimeCoins equals {value} years")
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
## Summary
- document supported time units in README
- expand `time_currency.py` to convert between TimeCoins and seconds, minutes, hours, days, months, or years

## Testing
- `python3 time_currency.py --hours 2`
- `python3 time_currency.py --coins 120 --to hours`
- `python3 time_currency.py --seconds 180`
- `python3 time_currency.py --coins 180 --to seconds`


------
https://chatgpt.com/codex/tasks/task_e_688114f7ccd8833181f4b8dbc5ffffd0